### PR TITLE
Fix getRandomGrade to return a parsed random grade from selected grades

### DIFF
--- a/src/Components/App.jsx
+++ b/src/Components/App.jsx
@@ -115,9 +115,11 @@ export default function App(){
     }
     
     // gets a random grade by retrieving the true bools from our settingsData right now. then picks one randomly and returns it.
-    function getRandomGrade(){
-        const selectedGrades = Object.keys(settingsData).filter(filterObj)
-        return Math.floor((Math.random() * selectedGrades.length) + 1)
+    function getRandomGrade() {
+        const selectedGrades = Object.keys(settingsData)
+            .filter(filterObj)
+            .map(key => parseInt(key.replace("grade", "")));
+        return selectedGrades[Math.floor(Math.random() * selectedGrades.length)];
     }
 
 


### PR DESCRIPTION
If you previously selected grade 3 and 4 the function would randomly pick between 1 and 2, not 3 and 4 as it should. Therefore you always get easier kanji than expected.
<img width="2560" height="1277" alt="457090085-40fbccd1-73b2-4de2-9491-95b00b6d2cf8" src="https://github.com/user-attachments/assets/7e08a390-b4fc-44ce-a260-4c700ec41a37" />
